### PR TITLE
Fixes fetch permissions when injecting the Faker Fact icon

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,8 +37,7 @@
     "contextMenus",
     "http://localhost:5000/",
     "http://localhost:3000/",
-    "http://*.twitter.com/",
-    "https://*.twitter.com/"
+    "<all_urls>"
   ],
   "web_accessible_resources": [
     "images/*"


### PR DESCRIPTION
@zilkey r?

We need this entry in the manifest to prevent the cross-scripting permission issues of happening when opening the iframe after clicking on injected icons.